### PR TITLE
Update asteval.py

### DIFF
--- a/asteval/asteval.py
+++ b/asteval/asteval.py
@@ -131,9 +131,8 @@ class Interpreter(object):
                 usersyms = {}
             symtable = make_symbol_table(use_numpy=use_numpy, **usersyms)
 
-        symtable['print'] = self._printer
-
-        self.symtable = symtable
+        self.symtable = symtable.copy()
+        self.symtable['print'] = self._printer
         self._interrupt = None
         self.error = []
         self.error_msg = None


### PR DESCRIPTION
Intepreter now creates a copy of the symtable dict, rather than modify it directly.

I cannot tell if `symtable['print'] = self._printer
`is even used for anything..

By adding a reference to self._print in the symtable, we might get an unintended reference to the Intepreter object from elsewhere.
This leads to hard to track bugs, such as the one I finally tracked down, which can be replicated with:
```

import pickle
from asteval import Interpreter

class Obj: pass
o = Obj()
interpreter = Interpreter(o.__dict__)
interpreter.d = o.__dict__
pickle.dumps(o)

# -->
# TypeError: cannot serialize '_io.TextIOWrapper' object
```